### PR TITLE
Comment out dead and currently unworkable code

### DIFF
--- a/src/bdali.cpp
+++ b/src/bdali.cpp
@@ -707,9 +707,12 @@ uint8_t BDali::compare() {
   while(retry>0) {
     //compare is true if we received any activity on the bus as reply.
     //sometimes the reply is not registered... so only accept retry times 'no reply' as a real false compare
-    int16_t rv = GetQuery(DA_EXT_COMPARE,0x00);
-    if(rv == -STATUS_FRAME_ERROR) return 1;
-    if(rv == -STATUS_VALID) return 1;
+    int8_t rv = GetQuery(DA_EXT_COMPARE,0x00);
+// The GetQuery(...) method does NOT include the status information in its uin8_t (NOT int16_t) return value
+// until it does the following two lines are dead code - which likely means this code is currently not fully
+// operative:
+//    if(rv == -STATUS_FRAME_ERROR) return 1;
+//    if(rv == -STATUS_VALID) return 1;
     if(rv == 0xFF) return 1;
 
     retry--;


### PR DESCRIPTION
PLEASE ENABLE "ISSUES" FOR THIS REPOSITORY IT IS IMPOSSIBLE TO DISCUSS THINGS LIKE THIS WITHOUT THEM.

I am guessing that you intended to include the (left shifted by 8 bits) status register in the return value from `GetQuery(...)` but never got around to do it. As such the commissioning code is not going to be reliable IMHO - and this bug has been in since 8f6d9fbfc0d90c99718ace983109f6e61aa9893c.

I've raised this PR as a means to alert you that the line in the top level README.md:
> Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

is impossible if you haven't enabled "issues"!